### PR TITLE
[FEATURE] Making JSONChecker return simple boolean value by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 #JSONChecker changelog
 
+##v1.1.0
+
+###Compatibility
+
+No changes.
+
+###Changes list
+
+- check() method by default returns `true` or `false`
+- getLastReport() method added to return full report
+
 ##v1.0.0
 
 ###Compatibility

--- a/DOCS.md
+++ b/DOCS.md
@@ -12,6 +12,11 @@ var json = {},
 console.log(checker.check(json, 'object'));
 
 // OUTPUTS:
+// true
+
+console.log(checker.getLastReport());
+
+// OUTPUTS:
 // {
 //     valid: true,
 //     errors: [],

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ var valid = {};
 var invalid = 1;
 ```
 
-Output contains few informations, and the most important one is of course whether the object is valid or not, e.g.:
+Simple check returns boolean value: either `true` or `false`.
+
+Full output (after calling `getLastReport()` method) contains few informations, and the most important one is of course whether the object is valid or not, e.g.:
 ```
 {
     valid: true,        // or false
@@ -125,6 +127,7 @@ require([
 
     var checker = new JSONChecker(spec);
     console.log(checker.check(json, 'object'));
+    console.log(checker.getLastReport());
 });
 
 ```

--- a/script.js
+++ b/script.js
@@ -62,4 +62,5 @@ require([
 
     var checker = new JSONChecker(spec);
     console.log(checker.check(json, 'object'));
+    console.log(checker.getLastReport());
 });

--- a/src/JSONChecker.js
+++ b/src/JSONChecker.js
@@ -22,6 +22,8 @@ define([
 
     _.extend(JSONChecker.prototype, {
 
+        lastReport: null,
+
         /**
          * Performs check on the passed valid JSON value against specification
          * passed in a constructor.
@@ -50,17 +52,36 @@ define([
                 context = '';
             }
 
-            var rootNode = JSONNodeFactory.createNode(
-                json,
-                this.specification,
-                context
-            );
+            var i,
+                temp = false,
+                rootNode = JSONNodeFactory.createNode(
+                    json,
+                    this.specification,
+                    context
+                );
 
             if (rootNode) {
-                return rootNode.check();
-            } else {
-                return null;
+                this.lastReport = rootNode.check();
+                if (_.isArray(this.lastReport)) {
+                    for (i = 0; i < this.lastReport.length; i++) {
+                        if (_.isBoolean(this.lastReport[i].valid)) {
+                            temp = temp || this.lastReport[i].valid;
+                        }
+                    }
+                    return temp;
+                } else {
+                    if (_.isBoolean(this.lastReport.valid)) {
+                        return this.lastReport.valid;
+                    }
+                }
             }
+
+            return false;
+        },
+
+        getLastReport: function () {
+
+            return this.lastReport;
         }
     });
 

--- a/tests/jasmine/spec/JSONChecker/Array.js
+++ b/tests/jasmine/spec/JSONChecker/Array.js
@@ -10,25 +10,27 @@ define([
 
     describe("JSONChecker", function() {
 
-        var i, checker, args, result, comparer, temp,
+        var i, checker, args, result, comparer, temp1, temp2,
             tester = function (toBe) {
 
                 return function (arg) {
 
                     checker = new JSONChecker(arg.spec);
-                    result = checker.check(arg.json, arg['context']);
+                    result = checker.check(arg.json, arg.context);
+                    fullResult = checker.getLastReport();
 
                     // setting spec & json as they're always in result
-                    arg.result.spec = arg.spec;
-                    arg.result.json = arg.json;
+                    arg.fullResult.spec = arg.spec;
+                    arg.fullResult.json = arg.json;
 
                     comparer = new ObjectComparer();
-                    temp = comparer.areEqual(result, arg.result);
+                    temp1 = result === arg.result;
+                    temp2 = comparer.areEqual(fullResult, arg.fullResult);
 
-                    expect(temp).toBe(toBe);
+                    expect(temp1 && temp2).toBe(toBe);
 
-                    if (temp !== toBe) {
-                        console.log('not equal', result, arg.result);
+                    if (temp1 && temp2 !== toBe) {
+                        console.log('not equal', result, fullResult, arg.result, arg.fullResult);
                     }
                 };
             };
@@ -41,7 +43,8 @@ define([
                     {
                         json: [],
                         spec: { type: 'array' },
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -51,7 +54,8 @@ define([
                         json: [],
                         spec: { type: 'array' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -61,7 +65,8 @@ define([
                         json: [],
                         spec: { type: 'array' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context'
@@ -71,7 +76,8 @@ define([
                         json: [1, 2],
                         spec: { type: 'array', length: 2 },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context'
@@ -86,7 +92,8 @@ define([
                             ]
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context',
@@ -112,7 +119,8 @@ define([
                             length: 3
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context',
@@ -145,7 +153,8 @@ define([
                             length: 4
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON array doesn't have required length"],
                             context: 'some.nested.context',
@@ -179,7 +188,8 @@ define([
                             length: 3
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: 'some.nested.context',
@@ -218,7 +228,8 @@ define([
                             length: 4
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON array doesn't have required length"],
                             context: 'some.nested.context',
@@ -240,7 +251,8 @@ define([
                             length: 4
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an array"],
                             context: 'some.nested.context'
@@ -250,7 +262,8 @@ define([
                         json: [],
                         spec: { type: 'array', length: 2 },
                         context: 'some.nested.context',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON array doesn't have required length"],
                             context: 'some.nested.context'
@@ -259,7 +272,8 @@ define([
                     {
                         json: 1,
                         spec: { type: 'array' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an array"],
                             context: ''
@@ -269,7 +283,8 @@ define([
                         json: true,
                         spec: { type: 'array' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an array"],
                             context: ''
@@ -279,7 +294,8 @@ define([
                         json: "string",
                         spec: { type: 'array' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an array"],
                             context: ''
@@ -289,7 +305,8 @@ define([
                         json: {},
                         spec: { type: 'array' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an array"],
                             context: ''
@@ -306,7 +323,8 @@ define([
                     {
                         json: [],
                         spec: { type: 'array' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: ''
@@ -316,7 +334,8 @@ define([
                         json: [],
                         spec: { type: 'array' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: ['some error'],
                             context: ''
@@ -326,7 +345,8 @@ define([
                         json: [],
                         spec: { type: 'array' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.invalid.context'

--- a/tests/jasmine/spec/JSONChecker/Boolean.js
+++ b/tests/jasmine/spec/JSONChecker/Boolean.js
@@ -10,25 +10,27 @@ define([
 
     describe("JSONChecker", function() {
 
-        var i, checker, args, result, comparer, temp,
+        var i, checker, args, result, comparer, temp1, temp2,
             tester = function (toBe) {
 
                 return function (arg) {
 
                     checker = new JSONChecker(arg.spec);
-                    result = checker.check(arg.json, arg['context']);
+                    result = checker.check(arg.json, arg.context);
+                    fullResult = checker.getLastReport();
 
                     // setting spec & json as they're always in result
-                    arg.result.spec = arg.spec;
-                    arg.result.json = arg.json;
+                    arg.fullResult.spec = arg.spec;
+                    arg.fullResult.json = arg.json;
 
                     comparer = new ObjectComparer();
-                    temp = comparer.areEqual(result, arg.result);
+                    temp1 = result === arg.result;
+                    temp2 = comparer.areEqual(fullResult, arg.fullResult);
 
-                    expect(temp).toBe(toBe);
+                    expect(temp1 && temp2).toBe(toBe);
 
-                    if (temp !== toBe) {
-                        console.log('not equal', result, arg.result);
+                    if (temp1 && temp2 !== toBe) {
+                        console.log('not equal', result, fullResult, arg.result, arg.fullResult);
                     }
                 };
             };
@@ -41,7 +43,8 @@ define([
                     {
                         json: false,
                         spec: { type: 'boolean' },
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -50,7 +53,8 @@ define([
                     {
                         json: true,
                         spec: { type: 'boolean' },
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -60,7 +64,8 @@ define([
                         json: false,
                         spec: { type: 'boolean' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -70,7 +75,8 @@ define([
                         json: true,
                         spec: { type: 'boolean' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -80,7 +86,8 @@ define([
                         json: false,
                         spec: { type: 'boolean' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context'
@@ -90,7 +97,8 @@ define([
                         json: true,
                         spec: { type: 'boolean' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context'
@@ -107,7 +115,8 @@ define([
                     {
                         json: false,
                         spec: { type: 'boolean' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: ''
@@ -116,7 +125,8 @@ define([
                     {
                         json: true,
                         spec: { type: 'boolean' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: ''
@@ -126,7 +136,8 @@ define([
                         json: false,
                         spec: { type: 'boolean' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: ['some error'],
                             context: ''
@@ -136,7 +147,8 @@ define([
                         json: true,
                         spec: { type: 'boolean' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: ['some error'],
                             context: ''
@@ -146,7 +158,8 @@ define([
                         json: false,
                         spec: { type: 'boolean' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.invalid.context'
@@ -156,7 +169,8 @@ define([
                         json: true,
                         spec: { type: 'boolean' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.invalid.context'

--- a/tests/jasmine/spec/JSONChecker/Number.js
+++ b/tests/jasmine/spec/JSONChecker/Number.js
@@ -10,25 +10,27 @@ define([
 
     describe("JSONChecker", function() {
 
-        var i, checker, args, result, comparer, temp,
+        var i, checker, args, result, comparer, temp1, temp2,
             tester = function (toBe) {
 
                 return function (arg) {
 
                     checker = new JSONChecker(arg.spec);
-                    result = checker.check(arg.json, arg['context']);
+                    result = checker.check(arg.json, arg.context);
+                    fullResult = checker.getLastReport();
 
                     // setting spec & json as they're always in result
-                    arg.result.spec = arg.spec;
-                    arg.result.json = arg.json;
+                    arg.fullResult.spec = arg.spec;
+                    arg.fullResult.json = arg.json;
 
                     comparer = new ObjectComparer();
-                    temp = comparer.areEqual(result, arg.result);
+                    temp1 = result === arg.result;
+                    temp2 = comparer.areEqual(fullResult, arg.fullResult);
 
-                    expect(temp).toBe(toBe);
+                    expect(temp1 && temp2).toBe(toBe);
 
-                    if (temp !== toBe) {
-                        console.log('not equal', result, arg.result);
+                    if (temp1 && temp2 !== toBe) {
+                        console.log('not equal', result, fullResult, arg.result, arg.fullResult);
                     }
                 };
             };
@@ -41,7 +43,8 @@ define([
                     {
                         json: 1,
                         spec: { type: 'number' },
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -51,7 +54,8 @@ define([
                         json: 1,
                         spec: { type: 'number' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -61,7 +65,8 @@ define([
                         json: 1,
                         spec: { type: 'number' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context'
@@ -78,7 +83,8 @@ define([
                     {
                         json: 1,
                         spec: { type: 'number' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: ''
@@ -88,7 +94,8 @@ define([
                         json: 1,
                         spec: { type: 'number' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: ['some error'],
                             context: ''
@@ -98,7 +105,8 @@ define([
                         json: 1,
                         spec: { type: 'number' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.invalid.context'

--- a/tests/jasmine/spec/JSONChecker/OR.js
+++ b/tests/jasmine/spec/JSONChecker/OR.js
@@ -10,31 +10,33 @@ define([
 
     describe("JSONChecker", function() {
 
-        var i, checker, args, result, comparer, temp,
+        var i, checker, args, result, comparer, temp1, temp2,
             tester = function (toBe) {
 
                 return function (arg) {
 
                     checker = new JSONChecker(arg.spec);
-                    result = checker.check(arg.json, arg['context']);
+                    result = checker.check(arg.json, arg.context);
+                    fullResult = checker.getLastReport();
 
                     // setting spec & json as they're always in result
                     for (i = 0; i < arg.spec.length; i++) {
-                        if (_.isArray(arg.result)) {
-                            arg.result[i].spec = arg.spec[i];
-                            arg.result[i].json = arg.json;
+                        if (_.isArray(arg.fullResult)) {
+                            arg.fullResult[i].spec = arg.spec[i];
+                            arg.fullResult[i].json = arg.json;
                         } else {
-                            arg.result.spec = arg.spec[i];
-                            arg.result.json = arg.json;
+                            arg.fullResult.spec = arg.spec[i];
+                            arg.fullResult.json = arg.json;
                         }
                     }
 
                     comparer = new ObjectComparer();
-                    temp = comparer.areEqual(result, arg.result);
+                    temp1 = result === arg.result;
+                    temp2 = comparer.areEqual(fullResult, arg.fullResult);
 
-                    expect(temp).toBe(toBe);
+                    expect(temp1 && temp2).toBe(toBe);
 
-                    if (temp !== toBe) {
+                    if (temp1 && temp2 !== toBe) {
                         console.log('not equal', result, arg.result);
                     }
                 };
@@ -52,7 +54,8 @@ define([
                         }, {
                             type: 'number'
                         }],
-                        result: [{
+                        result: true,
+                        fullResult: [{
                             valid: true,
                             errors: [],
                             context: ''
@@ -77,7 +80,8 @@ define([
                         }, {
                             type: 'number'
                         }],
-                        result: [{
+                        result: true,
+                        fullResult: [{
                             valid: true,
                             errors: [],
                             context: '',
@@ -117,7 +121,8 @@ define([
                         }, {
                             type: 'number'
                         }],
-                        result: [{
+                        result: false,
+                        fullResult: [{
                             valid: false,
                             errors: [],
                             context: '',
@@ -157,7 +162,8 @@ define([
                         }, {
                             type: 'number'
                         }],
-                        result: [{
+                        result: true,
+                        fullResult: [{
                             valid: true,
                             errors: [],
                             context: '',
@@ -197,7 +203,8 @@ define([
                         }, {
                             type: 'number'
                         }],
-                        result: [{
+                        result: false,
+                        fullResult: [{
                             valid: false,
                             errors: [],
                             context: '',
@@ -227,7 +234,8 @@ define([
                         spec: [{
                             type: 'object'
                         }],
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''

--- a/tests/jasmine/spec/JSONChecker/Object.js
+++ b/tests/jasmine/spec/JSONChecker/Object.js
@@ -10,25 +10,27 @@ define([
 
     describe("JSONChecker", function() {
 
-        var i, checker, args, result, comparer, temp,
+        var i, checker, args, result, comparer, temp1, temp2,
             tester = function (toBe) {
 
                 return function (arg) {
 
                     checker = new JSONChecker(arg.spec);
-                    result = checker.check(arg.json, arg['context']);
+                    result = checker.check(arg.json, arg.context);
+                    fullResult = checker.getLastReport();
 
                     // setting spec & json as they're always in result
-                    arg.result.spec = arg.spec;
-                    arg.result.json = arg.json;
+                    arg.fullResult.spec = arg.spec;
+                    arg.fullResult.json = arg.json;
 
                     comparer = new ObjectComparer();
-                    temp = comparer.areEqual(result, arg.result);
+                    temp1 = result === arg.result;
+                    temp2 = comparer.areEqual(fullResult, arg.fullResult);
 
-                    expect(temp).toBe(toBe);
+                    expect(temp1 && temp2).toBe(toBe);
 
-                    if (temp !== toBe) {
-                        console.log('not equal', result, arg.result);
+                    if (temp1 && temp2 !== toBe) {
+                        console.log('not equal', result, fullResult, arg.result, arg.fullResult);
                     }
                 };
             };
@@ -41,7 +43,8 @@ define([
                     {
                         json: {},
                         spec: { type: 'object' },
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -51,7 +54,8 @@ define([
                         json: {},
                         spec: { type: 'object' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -61,7 +65,8 @@ define([
                         json: {},
                         spec: { type: 'object' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context'
@@ -76,7 +81,8 @@ define([
                             ]
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context',
@@ -101,7 +107,8 @@ define([
                             ]
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context',
@@ -134,7 +141,8 @@ define([
                             ]
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: 'some.nested.context',
@@ -169,7 +177,8 @@ define([
                             type: 'object'
                         },
                         context: 'some.nested.context',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an object"],
                             context: 'some.nested.context'
@@ -178,7 +187,8 @@ define([
                     {
                         json: 1,
                         spec: { type: 'object' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an object"],
                             context: ''
@@ -188,7 +198,8 @@ define([
                         json: true,
                         spec: { type: 'object' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an object"],
                             context: ''
@@ -198,7 +209,8 @@ define([
                         json: "string",
                         spec: { type: 'object' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an object"],
                             context: ''
@@ -208,7 +220,8 @@ define([
                         json: [],
                         spec: { type: 'object' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not an object"],
                             context: ''
@@ -225,7 +238,8 @@ define([
                     {
                         json: {},
                         spec: { type: 'object' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: ''
@@ -235,7 +249,8 @@ define([
                         json: {},
                         spec: { type: 'object' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: ['some error'],
                             context: ''
@@ -245,7 +260,8 @@ define([
                         json: {},
                         spec: { type: 'object' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.invalid.context'

--- a/tests/jasmine/spec/JSONChecker/String.js
+++ b/tests/jasmine/spec/JSONChecker/String.js
@@ -10,25 +10,27 @@ define([
 
     describe("JSONChecker", function() {
 
-        var i, checker, args, result, comparer, temp,
+        var i, checker, args, result, comparer, temp1, temp2,
             tester = function (toBe) {
 
                 return function (arg) {
 
                     checker = new JSONChecker(arg.spec);
-                    result = checker.check(arg.json, arg['context']);
+                    result = checker.check(arg.json, arg.context);
+                    fullResult = checker.getLastReport();
 
                     // setting spec & json as they're always in result
-                    arg.result.spec = arg.spec;
-                    arg.result.json = arg.json;
+                    arg.fullResult.spec = arg.spec;
+                    arg.fullResult.json = arg.json;
 
                     comparer = new ObjectComparer();
-                    temp = comparer.areEqual(result, arg.result);
+                    temp1 = result === arg.result;
+                    temp2 = comparer.areEqual(fullResult, arg.fullResult);
 
-                    expect(temp).toBe(toBe);
+                    expect(temp1 && temp2).toBe(toBe);
 
-                    if (temp !== toBe) {
-                        console.log('not equal', result, arg.result);
+                    if (temp1 && temp2 !== toBe) {
+                        console.log('not equal', result, fullResult, arg.result, arg.fullResult);
                     }
                 };
             };
@@ -41,7 +43,8 @@ define([
                     {
                         json: "string",
                         spec: { type: 'string' },
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -51,7 +54,8 @@ define([
                         json: "string",
                         spec: { type: 'string' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -61,7 +65,8 @@ define([
                         json: "string",
                         spec: { type: 'string' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.nested.context'
@@ -70,7 +75,8 @@ define([
                     {
                         json: 1,
                         spec: { type: 'string' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not a string"],
                             context: ''
@@ -80,7 +86,8 @@ define([
                         json: true,
                         spec: { type: 'string' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not a string"],
                             context: ''
@@ -90,7 +97,8 @@ define([
                         json: [],
                         spec: { type: 'string' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not a string"],
                             context: ''
@@ -100,7 +108,8 @@ define([
                         json: {},
                         spec: { type: 'string' },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON is not a string"],
                             context: ''
@@ -110,7 +119,8 @@ define([
                         json: "a",
                         spec: { type: 'string', length: 1 },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: ''
@@ -120,7 +130,8 @@ define([
                         json: "a",
                         spec: { type: 'string', length: 2 },
                         context: '',
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: ["Provided JSON string doesn't have required length"],
                             context: ''
@@ -137,7 +148,8 @@ define([
                     {
                         json: "string",
                         spec: { type: 'string' },
-                        result: {
+                        result: false,
+                        fullResult: {
                             valid: false,
                             errors: [],
                             context: ''
@@ -147,7 +159,8 @@ define([
                         json: "string",
                         spec: { type: 'string' },
                         context: '',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: ['some error'],
                             context: ''
@@ -157,7 +170,8 @@ define([
                         json: "string",
                         spec: { type: 'string' },
                         context: 'some.nested.context',
-                        result: {
+                        result: true,
+                        fullResult: {
                             valid: true,
                             errors: [],
                             context: 'some.invalid.context'


### PR DESCRIPTION
- modifying behaviour of check() method
- getLastReport() method added

https://trello.com/c/AIbtudqB/1-by-default-jsonchecker-should-only-return-boolean-value-whether-it-s-valid
